### PR TITLE
The order the questions are shown in the results screen of the client is now the same order they are shown during the exam.

### DIFF
--- a/iTestClient/client.cpp
+++ b/iTestClient/client.cpp
@@ -185,7 +185,7 @@ void MainWindow::loadResults(QTableWidget * tw)
     tw->setRowCount(questions.count());
     bool highlight_correct_answers = !rbtnFromFile->isChecked() && !hideCorrectAnswersCheckBox->isChecked();
     for (int i = 0; i < questions.count(); ++i) {
-        tw->setCellWidget(i, 0, new QuestionWidget(questions.at(i), highlight_correct_answers));
+        tw->setCellWidget(i, 0, new QuestionWidget(current_test_questions.value(LQListWidget->item(i)), highlight_correct_answers));
         tw->setRowHeight(i, tw->cellWidget(i, 0)->sizeHint().height());
     }
 }


### PR DESCRIPTION
Either the questions were shuffled or not during the exam, they were shown in a different order in the last screen of the client, so it was difficult for the students to see their faults.
